### PR TITLE
Use onpar to organize and group tests

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -13,221 +13,171 @@ import (
 	logcache "code.cloudfoundry.org/go-log-cache"
 	rpc "code.cloudfoundry.org/go-log-cache/rpc/logcache"
 	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"github.com/apoydence/onpar"
+	. "github.com/apoydence/onpar/expect"
+	. "github.com/apoydence/onpar/matchers"
 	"google.golang.org/grpc"
 )
 
+type TC struct {
+	*testing.T
+	logCache *stubLogCache
+	client   *logcache.Client
+}
+
+type TG struct {
+	*testing.T
+	logCache *stubGrpcLogCache
+	client   *logcache.Client
+}
+
 func TestClientRead(t *testing.T) {
 	t.Parallel()
-	logCache := newStubLogCache()
-	client := logcache.NewClient(logCache.addr())
+	o := onpar.New()
+	defer o.Run(t)
 
-	envelopes, err := client.Read(context.Background(), "some-id", time.Unix(0, 99))
+	o.Group("RESTful client", func() {
+		o.BeforeEach(func(t *testing.T) TC {
+			logCache := newStubLogCache()
+			client := logcache.NewClient(logCache.addr())
+			return TC{
+				T:        t,
+				logCache: logCache,
+				client:   client,
+			}
+		})
 
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+		o.Spec("it reads from the client", func(t TC) {
+			envelopes, err := t.client.Read(context.Background(), "some-id", time.Unix(0, 99))
 
-	if len(envelopes) != 2 {
-		t.Fatalf("expected to receive 2 envelopes, got %d", len(envelopes))
-	}
+			Expect(t, err).To(BeNil())
+			Expect(t, envelopes).To(HaveLen(2))
+			Expect(t, envelopes[0].Timestamp).To(Equal(int64(99)))
+			Expect(t, envelopes[1].Timestamp).To(Equal(int64(100)))
+			Expect(t, t.logCache.reqs).To(HaveLen(1))
+			Expect(t, t.logCache.reqs[0].URL.Path).To(Equal("/v1/read/some-id"))
 
-	if envelopes[0].Timestamp != 99 || envelopes[1].Timestamp != 100 {
-		t.Fatal("wrong envelopes")
-	}
+			assertQueryParam(t.T, t.logCache.reqs[0].URL, "start_time", "99")
+			Expect(t, t.logCache.reqs[0].URL.Query()).To(HaveLen(1))
+		})
 
-	if len(logCache.reqs) != 1 {
-		t.Fatalf("expected have 1 request, have %d", len(logCache.reqs))
-	}
+		o.Spec("it reads with options", func(t TC) {
+			_, err := t.client.Read(
+				context.Background(),
+				"some-id",
+				time.Unix(0, 99),
+				logcache.WithEndTime(time.Unix(0, 101)),
+				logcache.WithLimit(103),
+				logcache.WithEnvelopeType(rpc.EnvelopeTypes_LOG),
+			)
 
-	if logCache.reqs[0].URL.Path != "/v1/read/some-id" {
-		t.Fatalf("expected Path '/v1/read/some-id' but got '%s'", logCache.reqs[0].URL.Path)
-	}
+			Expect(t, err).To(BeNil())
+			Expect(t, t.logCache.reqs).To(HaveLen(1))
+			Expect(t, t.logCache.reqs[0].URL.Path).To(Equal("/v1/read/some-id"))
 
-	assertQueryParam(t, logCache.reqs[0].URL, "start_time", "99")
+			assertQueryParam(t.T, t.logCache.reqs[0].URL, "start_time", "99")
+			assertQueryParam(t.T, t.logCache.reqs[0].URL, "end_time", "101")
+			assertQueryParam(t.T, t.logCache.reqs[0].URL, "limit", "103")
+			assertQueryParam(t.T, t.logCache.reqs[0].URL, "envelope_type", "LOG")
+			Expect(t, t.logCache.reqs[0].URL.Query()).To(HaveLen(4))
+		})
 
-	if len(logCache.reqs[0].URL.Query()) != 1 {
-		t.Fatalf("expected only a single query parameter, but got %d", len(logCache.reqs[0].URL.Query()))
-	}
-}
+		o.Spec("it returns an error for a non 200 response", func(t TC) {
+			t.logCache.statusCode = 500
+			_, err := t.client.Read(context.Background(), "some-id", time.Unix(0, 99))
 
-func TestGrpcClientRead(t *testing.T) {
-	t.Parallel()
-	logCache := newStubGrpcLogCache()
-	client := logcache.NewClient(logCache.addr(), logcache.WithViaGRPC(grpc.WithInsecure()))
+			Expect(t, err).To(Not(BeNil()))
+		})
 
-	endTime := time.Now()
+		o.Spec("it returns an error for an invalid response", func(t TC) {
+			t.logCache.result = []byte("invalid")
+			_, err := t.client.Read(context.Background(), "some-id", time.Unix(0, 99))
 
-	envelopes, err := client.Read(context.Background(), "some-id", time.Unix(0, 99),
-		logcache.WithLimit(10),
-		logcache.WithEndTime(endTime),
-		logcache.WithEnvelopeType(rpc.EnvelopeTypes_LOG),
-	)
+			Expect(t, err).To(Not(BeNil()))
+		})
 
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+		o.Spec("it returns an error for an unknown URL", func(t TC) {
+			client := logcache.NewClient("http://unknown.url")
+			_, err := client.Read(context.Background(), "some-id", time.Unix(0, 99))
 
-	if len(envelopes) != 2 {
-		t.Fatalf("expected to receive 2 envelopes, got %d", len(envelopes))
-	}
+			Expect(t, err).To(Not(BeNil()))
+		})
 
-	if envelopes[0].Timestamp != 99 || envelopes[1].Timestamp != 100 {
-		t.Fatal("wrong envelopes")
-	}
+		o.Spec("it returns an error for an invalid URL", func(t TC) {
+			client := logcache.NewClient("-:-invalid")
+			_, err := client.Read(context.Background(), "some-id", time.Unix(0, 99))
 
-	if len(logCache.reqs) != 1 {
-		t.Fatalf("expected have 1 request, have %d", len(logCache.reqs))
-	}
+			Expect(t, err).To(Not(BeNil()))
+		})
 
-	if logCache.reqs[0].SourceId != "some-id" {
-		t.Fatalf("expected SourceId (%s) to equal %s", logCache.reqs[0].SourceId, "some-id")
-	}
+		o.Spec("it returns an error when the context is cancelled", func(t TC) {
+			t.logCache.block = true
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
 
-	if logCache.reqs[0].StartTime != 99 {
-		t.Fatalf("expected StartTime (%d) to equal %d", logCache.reqs[0].StartTime, 99)
-	}
+			_, err := t.client.Read(
+				ctx,
+				"some-id",
+				time.Unix(0, 99),
+				logcache.WithEndTime(time.Unix(0, 101)),
+				logcache.WithLimit(103),
+				logcache.WithEnvelopeType(rpc.EnvelopeTypes_LOG),
+			)
+			Expect(t, err).To(Not(BeNil()))
+		})
+	})
 
-	if logCache.reqs[0].EndTime != endTime.UnixNano() {
-		t.Fatalf("expected EndTime (%d) to equal %d", logCache.reqs[0].EndTime, endTime.UnixNano())
-	}
+	o.Group("gRPC client", func() {
+		o.BeforeEach(func(t *testing.T) TG {
+			logCache := newStubGrpcLogCache()
+			client := logcache.NewClient(
+				logCache.addr(),
+				logcache.WithViaGRPC(grpc.WithInsecure()),
+			)
+			return TG{
+				T:        t,
+				logCache: logCache,
+				client:   client,
+			}
+		})
 
-	if logCache.reqs[0].Limit != 10 {
-		t.Fatalf("expected Limit (%d) to equal %d", logCache.reqs[0].Limit, 10)
-	}
+		o.Spec("it reads from the client", func(t TG) {
+			endTime := time.Now()
 
-	if logCache.reqs[0].EnvelopeType != rpc.EnvelopeTypes_LOG {
-		t.Fatalf("expected EnvelopeType (%v) to equal %v", logCache.reqs[0].EnvelopeType, rpc.EnvelopeTypes_LOG)
-	}
-}
+			envelopes, err := t.client.Read(context.Background(), "some-id", time.Unix(0, 99),
+				logcache.WithLimit(10),
+				logcache.WithEndTime(endTime),
+				logcache.WithEnvelopeType(rpc.EnvelopeTypes_LOG),
+			)
 
-func TestClientReadWithOptions(t *testing.T) {
-	t.Parallel()
-	logCache := newStubLogCache()
-	client := logcache.NewClient(logCache.addr())
+			Expect(t, err).To(BeNil())
+			Expect(t, envelopes).To(HaveLen(2))
+			Expect(t, envelopes[0].Timestamp).To(Equal(int64(99)))
+			Expect(t, envelopes[1].Timestamp).To(Equal(int64(100)))
+			Expect(t, t.logCache.reqs).To(HaveLen(1))
+			Expect(t, t.logCache.reqs[0].SourceId).To(Equal("some-id"))
+			Expect(t, t.logCache.reqs[0].StartTime).To(Equal(int64(99)))
+			Expect(t, t.logCache.reqs[0].EndTime).To(Equal(endTime.UnixNano()))
+			Expect(t, t.logCache.reqs[0].Limit).To(Equal(int64(10)))
+			Expect(t, t.logCache.reqs[0].EnvelopeType).To(Equal(rpc.EnvelopeTypes_LOG))
+		})
 
-	_, err := client.Read(
-		context.Background(),
-		"some-id",
-		time.Unix(0, 99),
-		logcache.WithEndTime(time.Unix(0, 101)),
-		logcache.WithLimit(103),
-		logcache.WithEnvelopeType(rpc.EnvelopeTypes_LOG),
-	)
+		o.Spec("it returns an error when the context is cancelled", func(t TG) {
+			t.logCache.block = true
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
 
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	if len(logCache.reqs) != 1 {
-		t.Fatalf("expected have 1 request, have %d", len(logCache.reqs))
-	}
-
-	if logCache.reqs[0].URL.Path != "/v1/read/some-id" {
-		t.Fatalf("expected Path '/v1/read/some-id' but got '%s'", logCache.reqs[0].URL.Path)
-	}
-
-	assertQueryParam(t, logCache.reqs[0].URL, "start_time", "99")
-	assertQueryParam(t, logCache.reqs[0].URL, "end_time", "101")
-	assertQueryParam(t, logCache.reqs[0].URL, "limit", "103")
-	assertQueryParam(t, logCache.reqs[0].URL, "envelope_type", "LOG")
-
-	if len(logCache.reqs[0].URL.Query()) != 4 {
-		t.Fatalf("expected only 4 query parameters, but got %d", len(logCache.reqs[0].URL.Query()))
-	}
-}
-
-func TestClientReadNon200(t *testing.T) {
-	t.Parallel()
-	logCache := newStubLogCache()
-	logCache.statusCode = 500
-	client := logcache.NewClient(logCache.addr())
-
-	_, err := client.Read(context.Background(), "some-id", time.Unix(0, 99))
-
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-}
-
-func TestClientReadInvalidResponse(t *testing.T) {
-	t.Parallel()
-	logCache := newStubLogCache()
-	logCache.result = []byte("invalid")
-	client := logcache.NewClient(logCache.addr())
-
-	_, err := client.Read(context.Background(), "some-id", time.Unix(0, 99))
-
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-}
-
-func TestClientReadUnknownAddr(t *testing.T) {
-	t.Parallel()
-	client := logcache.NewClient("http://invalid.url")
-
-	_, err := client.Read(context.Background(), "some-id", time.Unix(0, 99))
-
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-}
-
-func TestClientReadInvalidAddr(t *testing.T) {
-	t.Parallel()
-	client := logcache.NewClient("-:-invalid")
-
-	_, err := client.Read(context.Background(), "some-id", time.Unix(0, 99))
-
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-}
-
-func TestClientReadCancelling(t *testing.T) {
-	t.Parallel()
-	logCache := newStubLogCache()
-	logCache.block = true
-	client := logcache.NewClient(logCache.addr())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	_, err := client.Read(
-		ctx,
-		"some-id",
-		time.Unix(0, 99),
-		logcache.WithEndTime(time.Unix(0, 101)),
-		logcache.WithLimit(103),
-		logcache.WithEnvelopeType(rpc.EnvelopeTypes_LOG),
-	)
-
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-}
-
-func TestGrpcClientReadCancelling(t *testing.T) {
-	t.Parallel()
-	logCache := newStubGrpcLogCache()
-	logCache.block = true
-	client := logcache.NewClient(logCache.addr(), logcache.WithViaGRPC(grpc.WithInsecure()))
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	_, err := client.Read(
-		ctx,
-		"some-id",
-		time.Unix(0, 99),
-		logcache.WithEndTime(time.Unix(0, 101)),
-		logcache.WithLimit(103),
-		logcache.WithEnvelopeType(rpc.EnvelopeTypes_LOG),
-	)
-
-	if err == nil {
-		t.Fatal("expected an error")
-	}
+			_, err := t.client.Read(
+				ctx,
+				"some-id",
+				time.Unix(0, 99),
+				logcache.WithEndTime(time.Unix(0, 101)),
+				logcache.WithLimit(103),
+				logcache.WithEnvelopeType(rpc.EnvelopeTypes_LOG),
+			)
+			Expect(t, err).To(Not(BeNil()))
+		})
+	})
 }
 
 type stubLogCache struct {


### PR DESCRIPTION
I was looking into adding functionality for groups, but noticed because we were using vanilla tests, the amount of boiler-plate was growing quickly. I thought adding some organization might be helpful.